### PR TITLE
Upgrade pip before installing other things

### DIFF
--- a/scripts/startup-script.py
+++ b/scripts/startup-script.py
@@ -223,6 +223,12 @@ def install_packages():
         print "yum failed to install packages. Trying again in 5 seconds"
         time.sleep(5)
 
+
+    while subprocess.call(['pip', 'install', '--upgrade',
+        'pip']):
+        print "failed to install newer version of pip. Trying again 5 seconds."
+        time.sleep(5)
+        
     while subprocess.call(['pip', 'install', '--upgrade',
         'cachetools==3.1.1', 'google-api-python-client']):
         print "failed to install google python api client. Trying again 5 seconds."


### PR DESCRIPTION
It turns out you need a newer version of pip, more than anything else, to resolve some newer dependencies. Otherwise the script will keep on trying to install forever.